### PR TITLE
Update to latest sonar-python that runs under this infrastructure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
     compile("com.github.codeclimate:codeclimate-ss-analyzer-wrapper:master-SNAPSHOT")
 
     // Plugins
-    compile("org.sonarsource.python:sonar-python-plugin:1.8.0.1496")
+    compile("org.sonarsource.python:sonar-python-plugin:1.9.1.2080")
 
     testCompile("org.assertj:assertj-core:2.8.0")
     testCompile("org.skyscreamer:jsonassert:1.5.0")


### PR DESCRIPTION
Trying to address some false positives that were solved on 1.9+ using
new string interpolation format for python 3.6+

I also tried to upgrade to newer version on sonar-python but anything
behind 1.9.1.2080 does fail with a java.lang.NoClassDefFoundError,
probably some changes are required at infrastructure level.